### PR TITLE
월급쟁이부자들 강의 학습 종료일 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 |**시작일**|**종료일**|**요일**|**모임**|**주제**|**비고**|
 |:---:|:---:|:---:|:---:|:---:|:---:|
 | 2026.01.18 | 2026.01.31 | 매일 | Private | 엔터프라이즈 애플리케이션 아키텍처 패턴 독서/정리 | [Patterns_of_Enterprise_Application_Architecture](https://github.com/SeokRae/Patterns_of_Enterprise_Application_Architecture) |
-| 2026.01.01 | 2026.02.10 | 매일 | Private | 월급쟁이부자들 강의 학습 | [wolbu-roadmap](https://github.com/SeokRae/wolbu-roadmap) |
+| 2026.01.01 | 2026.01.28 | 매일 | Private | 월급쟁이부자들 강의 학습 | [wolbu-roadmap](https://github.com/SeokRae/wolbu-roadmap) |
 | - | - | 매일 | Private | 역량 강화 로드맵 | [Resume](https://github.com/SeokRae/resume) |
 | - | - | 매일 | Private | 결제 시스템 흐름 관측(Observability) 학습 | [payment-transaction-performance-observability](https://github.com/SeokRae/payment-transaction-performance-observability) |
 | - | - | 매일 | Private | Slack API 분석/샘플 어댑터 설계 | [slack](https://github.com/SeokRae/slack) |


### PR DESCRIPTION
## Summary
- 월급쟁이부자들 강의 학습 완료에 따른 종료일 업데이트
- 종료일: 2026.02.10 → 2026.01.28

## Changes
- README.md 학습 테이블의 월급쟁이부자들 강의 항목 종료일 수정

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)