### PR TITLE
Remove '요일' column from learning schedule table (#14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### README.md 학습 테이블 형식
 ```markdown
-|**시작일**|**종료일**|**요일**|**모임**|**주제**|**비고**|
-|:---:|:---:|:---:|:---:|:---:|:---:|
-| YYYY.MM.DD | YYYY.MM.DD | 요일 | 그룹명 | 주제 | [링크](URL) |
+|**시작일**|**종료일**|**모임**|**주제**|**비고**|
+|:---:|:---:|:---:|:---:|:---:|
+| YYYY.MM.DD | YYYY.MM.DD | 그룹명 | 주제 | [링크](URL) |
 ```
 
 ### 날짜 형식

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 - 🌱 I’m currently learning ...
 
-|**시작일**|**종료일**|**요일**|**모임**|**주제**|**비고**|
-|:---:|:---:|:---:|:---:|:---:|:---:|
-| 2026.01.30 | - | 매일 | Private | 모던 API 아키텍처 패턴 독서/정리 | [modern-api-architecture](https://github.com/SeokRae/modern-api-architecture) |
-| 2026.01.18 | 2026.01.31 | 매일 | Private | 엔터프라이즈 애플리케이션 아키텍처 패턴 독서/정리 | [Patterns_of_Enterprise_Application_Architecture](https://github.com/SeokRae/Patterns_of_Enterprise_Application_Architecture) |
-| 2026.01.01 | 2026.01.28 | 매일 | Private | 월급쟁이부자들 강의 학습 | [wolbu-roadmap](https://github.com/SeokRae/wolbu-roadmap) |
-| - | - | 매일 | Private | 역량 강화 로드맵 | [Resume](https://github.com/SeokRae/resume) |
-| - | - | 매일 | Private | 결제 시스템 흐름 관측(Observability) 학습 | [payment-transaction-performance-observability](https://github.com/SeokRae/payment-transaction-performance-observability) |
-| - | - | 매일 | Private | Slack API 분석/샘플 어댑터 설계 | [slack](https://github.com/SeokRae/slack) |
-| 2025.11.29 | 2025.11.30 | 매일 | Private | 일 잘하는 엔지니어의 생각 기법 독서/정리 | [Thinking-Techniques-of-High-Performing-Engineers](https://github.com/SeokRae/Thinking-Techniques-of-High-Performing-Engineers) |
+|**시작일**|**종료일**|**모임**|**주제**|**비고**|
+|:---:|:---:|:---:|:---:|:---:|
+| 2026.01.30 | - | Private | 모던 API 아키텍처 패턴 독서/정리 | [modern-api-architecture](https://github.com/SeokRae/modern-api-architecture) |
+| 2026.01.18 | 2026.01.31 | Private | 엔터프라이즈 애플리케이션 아키텍처 패턴 독서/정리 | [Patterns_of_Enterprise_Application_Architecture](https://github.com/SeokRae/Patterns_of_Enterprise_Application_Architecture) |
+| 2026.01.01 | 2026.01.28 | Private | 월급쟁이부자들 강의 학습 | [wolbu-roadmap](https://github.com/SeokRae/wolbu-roadmap) |
+| - | - | Private | 역량 강화 로드맵 | [Resume](https://github.com/SeokRae/resume) |
+| - | - | Private | 결제 시스템 흐름 관측(Observability) 학습 | [payment-transaction-performance-observability](https://github.com/SeokRae/payment-transaction-performance-observability) |
+| - | - | Private | Slack API 분석/샘플 어댑터 설계 | [slack](https://github.com/SeokRae/slack) |
+| 2025.11.29 | 2025.11.30 | Private | 일 잘하는 엔지니어의 생각 기법 독서/정리 | [Thinking-Techniques-of-High-Performing-Engineers](https://github.com/SeokRae/Thinking-Techniques-of-High-Performing-Engineers) |
 
 <!-- |2024.09.20 ~ | 매주 수요일 | MeetCoder | 블로그 포스팅 | [posting](https://github.com/SeokRae/posting-review) | -->
 <!-- |2023.06.20 ~ , 21:00 ~ 22:00|매주 화요일|MeetCoder|모각글|-| -->


### PR DESCRIPTION
## Summary
- Remove '요일' (day-of-week) column from README.md learning schedule table
- Update CLAUDE.md to reflect the new table format

## Changes
- **README.md**: Removed '요일' column from table header and all data rows (7 rows)
- **CLAUDE.md**: Updated table format example in documentation

## Motivation
- Simplify table structure by removing unnecessary information
- Improve table readability and maintenance

## Related Issue
Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)